### PR TITLE
remove the minimize script for ubuntu

### DIFF
--- a/ubuntu/build.pkr.hcl
+++ b/ubuntu/build.pkr.hcl
@@ -33,7 +33,6 @@ build {
       "${path.root}/../scripts/ubuntu/base/systemd.sh",
       "${path.root}/../scripts/ubuntu/base/parallels.sh",
       "${path.root}/../scripts/ubuntu/base/parallels_folders.sh",
-      "${path.root}/../scripts/ubuntu/base/minimize.sh",
     ]
 
     execute_command   = "echo 'ubuntu' | {{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"


### PR DESCRIPTION
Removing the minimize script for Ubuntu, as this is not compatible with the latest versions.
fix #33 