### PR TITLE
fix the `packer build` command to reference the `variables.pkrvars.hcl`

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -110,7 +110,7 @@ The configuration is valid.
 To build the virtual machine, navigate to the directory containing the script and run the following command:
 
 ```bash
-packer build .
+packer build -var-file=variables.pkrvars.hcl .
 ```
 
 This will create a new virtual machine based on the configuration in the Packer script in the out folder. if you set the `create_vagrant_box` variable to `true` a Vagrant box will be created in the `out` folder.


### PR DESCRIPTION
This step may be obvious to some, but as someone who's new to packer (but experienced with vagrant), I had no idea how this worked. It took considerable internet research to discover this command line syntax.