### PR TITLE
Optionally remove Red Hat subscriptions

### DIFF
--- a/redhat/build.pkr.hcl
+++ b/redhat/build.pkr.hcl
@@ -106,6 +106,16 @@ build {
     expect_disconnect = true
   }
 
+  provisioner "shell" {
+
+    scripts = [
+      "${path.root}/../scripts/rhel/base/unsubscribe.sh",
+    ]
+
+    execute_command   = "echo '${local.username}' | {{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
+    expect_disconnect = true
+    except            = !var.redhat_unsubscribe ? ["parallels-iso.image"] : []
+  }
 
   post-processor "vagrant" {
     compression_level    = 9

--- a/redhat/variables.TEMPLATE.pkrvars.hcl
+++ b/redhat/variables.TEMPLATE.pkrvars.hcl
@@ -15,6 +15,7 @@ iso_url            = ""
 iso_checksum       = ""
 redhat_username    = ""
 redhat_password    = ""
+redhat_unsubscribe = false
 addons             = []
 install_desktop    = true
 create_vagrant_box = false

--- a/redhat/variables.md
+++ b/redhat/variables.md
@@ -31,6 +31,7 @@ This guide provides detailed explanations of the variables that can be set in th
 * `iso_checksum` - Specifies the checksum of the ISO file. If this is set, the script will validate the checksum of the ISO file after downloading it.
 * `redhat_username` - Specifies the username to use when registering your product.
 * `redhat_password` - Specifies the password to use when registering your product.
+* `redhat_unsubscribe` - Remove all subscriptions from the system.
 
 ## Additional Options
 

--- a/redhat/variables.pkr.hcl
+++ b/redhat/variables.pkr.hcl
@@ -120,3 +120,8 @@ variable "redhat_password" {
   type    = string
   default = ""
 }
+
+variable "redhat_unsubscribe" {
+  type    = bool
+  default = false
+}

--- a/scripts/rhel/base/unsubscribe.sh
+++ b/scripts/rhel/base/unsubscribe.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eux
+
+sudo subscription-manager remove --all
+sudo subscription-manager unregister
+sudo subscription-manager clean


### PR DESCRIPTION
When creating the box, Packer will add subscriptions using `redhat_username` and `redhat_password` in order to update the box and install addons. This will remove all of the subscriptions from the box.

This way, every Vagrant instance made from this box won't be already subscribed.