### PR TITLE
Add support for building Vagrant boxes with RHEL

### DIFF
--- a/redhat/build.pkr.hcl
+++ b/redhat/build.pkr.hcl
@@ -56,7 +56,7 @@ build {
   provisioner "shell" {
     environment_vars = [
       "HOME_DIR=/home/${local.username}",
-      "DEFAULT_USERNAME=${local.username}",
+      "USERNAME=${local.username}",
     ]
 
     scripts = [

--- a/redhat/build.pkr.hcl
+++ b/redhat/build.pkr.hcl
@@ -104,6 +104,7 @@ build {
 
     execute_command   = "echo 'rhel' | {{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
     expect_disconnect = true
+    except            = !var.create_vagrant_box ? ["parallels-iso.image"] : []
   }
 
 

--- a/scripts/rhel/base/vagrant.sh
+++ b/scripts/rhel/base/vagrant.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -eux
+
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/home/$USERNAME}"
+
+pubkey_url="https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub"
+mkdir -p "$HOME_DIR"/.ssh
+if command -v wget >/dev/null 2>&1; then
+  wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR"/.ssh/authorized_keys
+elif command -v curl >/dev/null 2>&1; then
+  curl --insecure --location "$pubkey_url" >"$HOME_DIR"/.ssh/authorized_keys
+elif command -v fetch >/dev/null 2>&1; then
+  fetch -am -o "$HOME_DIR"/.ssh/authorized_keys "$pubkey_url"
+else
+  echo "Cannot download vagrant public key"
+  exit 1
+fi
+
+wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR"/authorized_keys
+
+chown -R $USERNAME "$HOME_DIR"/.ssh
+chmod -R go-rwsx "$HOME_DIR"/.ssh


### PR DESCRIPTION
Changes the following:

- Don't force a password change for vagrant -- it breaks Vagrant.
- Copy the vagrant provisioning script from other, compatible Linux script folder; Was already referenced by the builder config, as just not present in script folder.
- Change vagrant provisioner environment to set `USERNAME` instead of `DEFAULT_USERNAME` because that's what is used in the provisioning script.

