### PR TITLE
Fix "Error: Unsupported argument"

### DIFF
--- a/macos/build.pkr.hcl
+++ b/macos/build.pkr.hcl
@@ -1,5 +1,4 @@
 build {
-  count   = 0
   sources = local.sources
 
   provisioner "file" {


### PR DESCRIPTION
Remove `count=0` from `build.pkr.hcl`.

I can't find where it is used (though I may have missed it), but it prevents checking validity and building.