### PR TITLE
macos: add insecure key for Vagrant box builds

### DIFF
--- a/macos/build.pkr.hcl
+++ b/macos/build.pkr.hcl
@@ -1,6 +1,22 @@
 build {
   sources = local.sources
 
+  ## Install the insecure Vagrant ssh key, if we're building a Vagrant box
+  provisioner "shell" {
+    environment_vars = [
+      "HOME_DIR=/Users/${local.username}",
+      "USERNAME=${local.username}",
+    ]
+
+    scripts = [
+      "${path.root}/../scripts/macos/base/vagrant_ssh_key.sh",
+    ]
+
+    execute_command   = "echo '${local.username}' | {{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
+    expect_disconnect = true
+    except            = !var.create_vagrant_box ? local.vagrant_sources : []
+  }
+
   provisioner "file" {
     source      = "${path.root}/../scripts/macos/addons"
     destination = "/Users/${local.username}/parallels-tools"

--- a/scripts/macos/base/vagrant_ssh_key.sh
+++ b/scripts/macos/base/vagrant_ssh_key.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -eux
+
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/Users/$USERNAME}"
+
+pubkey_url="https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub"
+mkdir -p "$HOME_DIR"/.ssh
+if command -v wget >/dev/null 2>&1; then
+  wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR"/.ssh/authorized_keys
+elif command -v curl >/dev/null 2>&1; then
+  curl --insecure --location "$pubkey_url" >"$HOME_DIR"/.ssh/authorized_keys
+elif command -v fetch >/dev/null 2>&1; then
+  fetch -am -o "$HOME_DIR"/.ssh/authorized_keys "$pubkey_url"
+else
+  echo "Cannot download vagrant public key"
+  exit 1
+fi
+
+chown -R $USERNAME "$HOME_DIR"/.ssh
+chmod -R go-rwsx "$HOME_DIR"/.ssh


### PR DESCRIPTION
There is no code to install the Vagrant insecure ssh key when building a Vagrant box containing macOS. This is copied from another part of the repo and changed to work on macOS.