### PR TITLE
Fix Kali provisioning

### DIFF
--- a/http/kali-linux/preseed.cfg.pkrtpl.hcl
+++ b/http/kali-linux/preseed.cfg.pkrtpl.hcl
@@ -129,7 +129,7 @@ d-i cdrom-detect/eject boolean true
 
 # Post-install commands
 d-i preseed/late_command string \
-    in-target curl -L -o /root/post-install.sh "https://raw.githubusercontent.com/Parallels/packer-examples/main/http/kali/post-install.sh"; \
+    in-target curl -L -o /root/post-install.sh "`cat /proc/cmdline | sed -n 's/.*url=\([^ ]*\)\/\.\/*.*$/\1/p'`/post-install.sh"; \
     in-target chmod +x /root/post-install.sh; \
     in-target /root/post-install.sh; \
     echo "${username} ALL=(ALL:ALL) NOPASSWD:ALL" > /target/etc/sudoers.d/${username} && chmod 0440 /target/etc/sudoers.d/${username}

--- a/kali-linux/provisioner.pkr.hcl
+++ b/kali-linux/provisioner.pkr.hcl
@@ -16,7 +16,7 @@ locals {
     "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
     "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
     "<bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-    "auto=true url=http://{{.HTTPIP}}:{{.HTTPPort}}/kali-linux/preseed.cfg priority=critical<f10><wait>"
+    "auto=true url=http://{{.HTTPIP}}:{{.HTTPPort}}/kali-linux/./preseed.cfg priority=critical<f10><wait>"
   ] : var.boot_command
 
   iso_url = var.iso_url == "" ? "https://cdimage.kali.org/kali-${var.version == "" ? "2023.3" : var.version}/kali-linux-${var.version == "" ? "2023.3" : var.version}-installer-arm64.iso" : var.iso_url
@@ -52,6 +52,7 @@ source "parallels-iso" "image" {
   http_content = {
     "/kali-linux/meta-data"   = templatefile("${path.root}/../http/kali-linux/meta-data.pkrtpl.hcl", { hostname = "${local.hostname}" })
     "/kali-linux/preseed.cfg" = templatefile("${path.root}/../http/kali-linux/preseed.cfg.pkrtpl.hcl", { username = "${local.username}", password = "${local.password}", hostname = "${local.hostname}", desktop = "${var.desktop}" })
+    "/kali-linux/post-install.sh" = file("${path.root}/../http/kali-linux/post-install.sh")
   }
 
   iso_url          = local.iso_url

--- a/scripts/kali-linux/base/vagrant.sh
+++ b/scripts/kali-linux/base/vagrant.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
 # set a default HOME_DIR environment variable if not set
-HOME_DIR="${HOME_DIR:-/home/$USERNAME}"
+HOME_DIR="${HOME_DIR:-/home/$USER}"
 
 pubkey_url="https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub"
 mkdir -p "$HOME_DIR"/.ssh
@@ -18,5 +18,5 @@ fi
 
 wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR"/authorized_keys
 
-chown -R $USERNAME "$HOME_DIR"/.ssh
+chown -R "$USER" "$HOME_DIR"/.ssh
 chmod -R go-rwsx "$HOME_DIR"/.ssh


### PR DESCRIPTION
Use the local Packer http server to provision the post-install.sh script on preseed. Fix the Vagrant Kali provisioning script using USER instead of USERNAME

Tested on Parallels Version 20.1.0 (55732) and Kali Linux 2024.3