### PR TITLE
Feature jbergman update macos15

### DIFF
--- a/macos/provisioner_sequoia.pkr.hcl
+++ b/macos/provisioner_sequoia.pkr.hcl
@@ -1,11 +1,25 @@
 source "parallels-ipsw" "sequoia" {
   output_directory = local.output_dir
-  boot_command     = ["<wait10s><enter>"]
 
   boot_screen_config {
     boot_command     = ["<wait2s><enter>"]
-    screen_name      = "Welcome"
+    screen_name      = "Empty"
     matching_strings = []
+  }
+  boot_screen_config {
+    boot_command     = ["<wait1s><enter>"]
+    screen_name      = "GetStarted1"
+    matching_strings = ["Get Started"]
+  }
+  boot_screen_config {
+    boot_command     = ["<wait1s><enter>"]
+    screen_name      = "GetStarted2"
+    matching_strings = ["hola"]
+  }
+  boot_screen_config {
+    boot_command     = ["<wait1s><enter>"]
+    screen_name      = "GetStarted3"
+    matching_strings = ["hallo"]
   }
   boot_screen_config {
     boot_command     = ["<tab><spacebar>"]
@@ -16,6 +30,11 @@ source "parallels-ipsw" "sequoia" {
     boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]
     screen_name      = "Country"
     matching_strings = ["Select Your Country or Region"]
+  }
+  boot_screen_config {
+    boot_command     = ["<tab><tab><tab><spacebar>"]
+    screen_name      = "MigrationAssistant"
+    matching_strings = ["Migration Assistant", "From a Mac", "Time Machine backup"]
   }
   boot_screen_config {
     boot_command = ["<tab><tab><tab><tab><spacebar><tab><tab><spacebar>"]
@@ -44,7 +63,7 @@ source "parallels-ipsw" "sequoia" {
   }
   boot_screen_config {
     boot_command     = ["<leftCtrlOn><f7><leftCtrlOff><wait1s><leftShiftOn><tab><leftShiftOff><spacebar>"]
-    screen_name      = "SignInWithApple"
+    screen_name      = "SignInToApple"
     matching_strings = ["Sign in to your apple", "Sign in to use iCloud"]
   }
   boot_screen_config {

--- a/macos/provisioner_sequoia.pkr.hcl
+++ b/macos/provisioner_sequoia.pkr.hcl
@@ -1,5 +1,6 @@
 source "parallels-ipsw" "sequoia" {
   output_directory = local.output_dir
+  boot_command     = local.boot_command
 
   boot_screen_config {
     boot_command     = ["<wait2s><enter>"]
@@ -22,9 +23,9 @@ source "parallels-ipsw" "sequoia" {
     matching_strings = ["hallo"]
   }
   boot_screen_config {
-    boot_command     = ["<tab><spacebar>"]
+    boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]
     screen_name      = "Language"
-    matching_strings = ["English", "Language"]
+    matching_strings = ["English", "Language", "Australia", "India"]
   }
   boot_screen_config {
     boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]

--- a/macos/provisioner_sequoia.pkr.hcl
+++ b/macos/provisioner_sequoia.pkr.hcl
@@ -1,36 +1,26 @@
 source "parallels-ipsw" "sequoia" {
   output_directory = local.output_dir
-  boot_command     = local.boot_command
+  boot_command     = ["<wait10s><enter>"]
 
   boot_screen_config {
     boot_command     = ["<wait2s><enter>"]
-    screen_name      = "Empty"
+    screen_name      = "Welcome"
     matching_strings = []
   }
   boot_screen_config {
-    boot_command     = ["<wait1s><enter>"]
-    screen_name      = "GetStarted1"
-    matching_strings = ["Get Started"]
-  }
-  boot_screen_config {
-    boot_command     = ["<wait1s><enter>"]
-    screen_name      = "GetStarted2"
-    matching_strings = ["hola"]
-  }
-  boot_screen_config {
-    boot_command     = ["<wait1s><enter>"]
-    screen_name      = "GetStarted3"
-    matching_strings = ["hallo"]
-  }
-  boot_screen_config {
-    boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]
+    boot_command     = ["<tab><spacebar>"]
     screen_name      = "Language"
-    matching_strings = ["English", "Language", "Australia", "India"]
+    matching_strings = ["English", "Language"]
   }
   boot_screen_config {
     boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]
     screen_name      = "Country"
     matching_strings = ["Select Your Country or Region"]
+  }
+  boot_screen_config {
+    boot_command = ["<tab><tab><tab><tab><spacebar><tab><tab><spacebar>"]
+    screen_name = "Data"
+    matching_strings = ["transfer", "information"]
   }
   boot_screen_config {
     boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]
@@ -48,19 +38,19 @@ source "parallels-ipsw" "sequoia" {
     matching_strings = ["Data", "Privacy", "This icon appears"]
   }
   boot_screen_config {
-    boot_command     = ["<tab><tab><tab><spacebar>"]
-    screen_name      = "MigrationAssistant"
-    matching_strings = ["Migration Assistant", "From a Mac", "Time Machine backup"]
+    boot_command     = ["${local.ssh_username}<tab><tab>${local.ssh_password}<tab>${local.ssh_password}<tab><tab><tab><tab><spacebar>"]
+    screen_name      = "CreateAccount"
+    matching_strings = ["Create a Mac Account", "The password you create here"]
   }
   boot_screen_config {
-    boot_command     = ["<leftShiftOn><tab><tab><leftShiftOff><spacebar>"]
+    boot_command     = ["<leftCtrlOn><f7><leftCtrlOff><wait1s><leftShiftOn><tab><leftShiftOff><spacebar>"]
+    screen_name      = "SignInWithApple"
+    matching_strings = ["Sign in to your apple", "Sign in to use iCloud"]
+  }
+  boot_screen_config {
+    boot_command     = ["<leftCtrlOn><f7><leftCtrlOff><wait1s><leftShiftOn><tab><leftShiftOff><spacebar>"]
     screen_name      = "SignInWithApple"
     matching_strings = ["Sign in with your apple", "Sign in to use iCloud"]
-  }
-  boot_screen_config {
-    boot_command     = ["<leftShiftOn><tab><tab><leftShiftOff><spacebar>"]
-    screen_name      = "SignInToApple"
-    matching_strings = ["Sign In to Your Apple Account", "Sign in to use iCloud"]
   }
   boot_screen_config {
     boot_command     = ["<tab><spacebar>"]
@@ -76,11 +66,6 @@ source "parallels-ipsw" "sequoia" {
     boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar><wait1s><tab><spacebar>"]
     screen_name      = "TermsAndConditionsUS"
     matching_strings = ["Terms and Conditions", "macOS Software License Agreement"] # for US, Licen's'e is used
-  }
-  boot_screen_config {
-    boot_command     = ["${local.ssh_username}<tab><tab>${local.ssh_password}<tab>${local.ssh_password}<tab><tab><tab><spacebar>"]
-    screen_name      = "CreateAccount"
-    matching_strings = ["Create a Computer Account", "Fill out the following information"]
   }
   boot_screen_config {
     boot_command     = ["<leftShiftOn><tab><leftShiftOff><spacebar><wait2s><tab><spacebar>"]
@@ -113,8 +98,17 @@ source "parallels-ipsw" "sequoia" {
     matching_strings = ["Choose your look", "Select an appearance"]
   }
   boot_screen_config {
+    boot_command = ["<leftShiftOn><tab><leftShiftOff><spacebar>"]
+    screen_name = "Update"
+    matching_strings = ["Update Mac Automatically"]
+  }
+  boot_screen_config {
+    boot_command = ["<spacebar>"]
+    screen_name = "Welcome to mac"
+    matching_strings = ["Welcome to Mac", "continue"]
+  }
+  boot_screen_config {
     boot_command     =  [
-      "<leftCtrlOn><f7><leftCtrlOff>", # Enable keyboard navigation
       "<leftShiftOn><leftSuperOn>G<leftSuperOff><leftShiftOff>/Applications/Utilities/Terminal.app<enter><leftSuperOn>o<leftSuperOff>", # Open terminal
       ]
     screen_name      = "Desktop"
@@ -182,7 +176,7 @@ source "parallels-ipsw" "sequoia" {
     screen_name      = "WelcomeScreen"
     matching_strings = ["Welcome to mac"]
   }
-
+#
   boot_wait        = "${var.boot_wait}"
   shutdown_command = "sudo shutdown -h now"
   ipsw_url         = local.ipsw_url


### PR DESCRIPTION
There are a few changes here.
1. [These Blocks](https://github.com/Parallels/packer-examples/compare/main...jbergman-oddball:packer-examples:feature-jbergman-update-macos15?expand=1#diff-065e658eb49f7cb5e74568c715fa59a4a289e26f95d79057babb8a4e5f517599R35) move some items around.  These were earlier in the Sequoia build.
2. [Create a computer account](https://github.com/Parallels/packer-examples/compare/main...jbergman-oddball:packer-examples:feature-jbergman-update-macos15?expand=1) is now `Create a Mac Account`.  It also has 1 more tab in the last set before navigating to the next page.
3. [Sign in to Apple](https://github.com/Parallels/packer-examples/compare/main...jbergman-oddball:packer-examples:feature-jbergman-update-macos15?expand=1) Is the big change.  It seems this is where keyboard navigation sort of quit. I enabled it in this screen as it worked prior to this screen.
4. [This Block](https://github.com/Parallels/packer-examples/compare/main...jbergman-oddball:packer-examples:feature-jbergman-update-macos15?expand=1) was updated and moved earlier in the config. (Point 2.)
5. [These Blocks](https://github.com/Parallels/packer-examples/compare/main...jbergman-oddball:packer-examples:feature-jbergman-update-macos15?expand=1) Were added to the end of the setup screens.
6. [Removed](https://github.com/Parallels/packer-examples/compare/main...jbergman-oddball:packer-examples:feature-jbergman-update-macos15?expand=1) the keyboard navigation enable as it was enabled earler.