### PR TITLE
Update broken link

### DIFF
--- a/macos/variables.TEMPLATE.pkrvars.hcl
+++ b/macos/variables.TEMPLATE.pkrvars.hcl
@@ -1,6 +1,6 @@
 version = "tahoe"
 machine_name = "macOs-26"
-ipsw_url      = "/Users/zayaan.dulmeer/Downloads/UniversalMac_26.0_25A354_Restore.ipsw"
+ipsw_url      = "https://updates.cdn-apple.com/2025FallFCS/fullrestores/093-37622/CE01FAB2-7F26-48EE-AEE4-5E57A7F6D8BB/UniversalMac_26.0_25A354_Restore.ipsw"
 ipsw_checksum = "sha256:ec98309d97fdc399f7baa5f1e11d121e8ffda798d885219fee9c4c94b4f219d6" 
 machine_specs = {
   cpus   = 4,


### PR DESCRIPTION
The TEMPLATE file has a broken/possibly outdated link, and this aims to fix it. Link taken from MrMactintosh for the (presumably) same macOS 26.0 25A354 ipsw.

Excuse the newline change, it is a side effect of me redacting the file directly in GitHub.