### PR TITLE
Ubuntu bump version

### DIFF
--- a/scripts/ubuntu/base/update.sh
+++ b/scripts/ubuntu/base/update.sh
@@ -1,8 +1,4 @@
 #!/bin/sh -eux
-
-echo "Forcing time sync..."
-sudo systemctl restart systemd-timesyncd
-sleep 15
 export DEBIAN_FRONTEND=noninteractive
 
 echo "disable release-upgrades"

--- a/ubuntu/variables.TEMPLATE.pkrvars.hcl
+++ b/ubuntu/variables.TEMPLATE.pkrvars.hcl
@@ -4,16 +4,16 @@ user = {
   password              = "parallels",
   force_password_change = true,
 }
-version      = "25.10"
-machine_name = "ubuntu_25.10"
-hostname     = "ubuntu-25.10"
+version      = "26.04"
+machine_name = "ubuntu_26.04"
+hostname     = "ubuntu-26.04"
 machine_specs = {
   cpus      = 2,
-  memory    = 2048,
+  memory    = 4096,
   disk_size = "65536",
 }
-iso_url      = "https://cdimage.ubuntu.com/releases/25.10/release/ubuntu-25.10-live-server-arm64.iso"
-iso_checksum = "sha256:ecf579664c0be9e4a68ae7b617399ce943c2dee49eb1fcc6702a5671a4f88320"
+iso_url      = "https://cdimage.ubuntu.com/releases/26.04/release/ubuntu-26.04-live-server-arm64.iso"
+iso_checksum = "sha256:c9aa567e6560b2eddae3af03fc686002e35b6fee96f97fd5df3271e846439fdd"
 addons = [
   "desktop"
 ]


### PR DESCRIPTION
# Description

Updated the TEMPLATE file to use the 26.04 LTS version.
Fixed an issue where the said Ubuntu version would not work due to the duplicate and unavoidable call to the systemd-timesyncd which is not present on newer versions of Ubuntu.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation Change | (maybe? Is template a documentation?)
- [ ] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests that prove my fix is effective or that my feature works
