### PR TITLE
Fedora version bump, Addon & tools fix

### DIFF
--- a/fedora/build.pkr.hcl
+++ b/fedora/build.pkr.hcl
@@ -29,10 +29,18 @@ build {
   }
 
   # Addons Installation
+ provisioner "file" {
+    source      = "${path.root}/../scripts/fedora/addons"
+    destination = "/parallels-tools"
+    direction   = "upload"
+    # Only skip if no addons are defined
+    except = length(var.addons) == 0 ? ["parallels-iso.image"] : []
+  }  
+
   provisioner "shell" {
     environment_vars = [
       "ADDONS=${local.addons}",
-      "ADDONS_DIR=${path.root}/../scripts/fedora/addons"
+      "ADDONS_DIR=/parallels-tools/addons"
     ]
     scripts = [
       "${path.root}/../scripts/fedora/addons/install.sh",

--- a/fedora/variables.TEMPLATE.pkrvars.hcl
+++ b/fedora/variables.TEMPLATE.pkrvars.hcl
@@ -3,16 +3,16 @@ user = {
   encrypted_password = "$6$parallels$tb6hm4RSqzwG3j51DSzdFD7Zw3Fxy/x5aen.Yvud7IfLqarIxMEuuM8efQy0gO.pHhT.lIz9tNYoppTGBGCsB/"
   password           = "parallels"
 }
-version      = "42-1.1"
-machine_name = "fedora-42 ARM"
+version      = "44"
+machine_name = "fedora-44 ARM"
 hostname     = "fedora-Server"
 machine_specs = {
   cpus      = 2,
   memory    = 4096,
   disk_size = "65536",
 }
-iso_url            = "https://fedora.c3sl.ufpr.br/linux/releases/42/Server/aarch64/iso/Fedora-Server-dvd-aarch64-42-1.1.iso"
-iso_checksum       = "sha256:6527d67f98627d3fa973d95475b008b7496bf9800c68fe00e91a4e020505d3c9"
+iso_url            = "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Server/aarch64/iso/Fedora-Server-dvd-aarch64-44-1.7.iso"
+iso_checksum       = "sha256:ba8372682294d0d76f79427cae1273d36891b192ac9bf0f0f9de4e97a7cbe218"
 
 
 addons             = []

--- a/scripts/fedora/base/parallels.sh
+++ b/scripts/fedora/base/parallels.sh
@@ -15,8 +15,7 @@ parallels-iso|parallels-pvm)
 
     mkdir -p /tmp/parallels;
     if [ "$(uname -m)" = "aarch64" ] ; then
-        mount -o loop "$HOME_DIR"/prl-tools-lin-arm.iso /
-        tmp/parallels;
+        mount -o loop "$HOME_DIR"/prl-tools-lin-arm.iso /tmp/parallels;
     else
         mount -o loop "$HOME_DIR"/prl-tools-lin.iso /tmp/parallels;
     fi


### PR DESCRIPTION
# Description

Our addon installation works via provisioning the installation scripts into the VM and running them from inside, while this one used to keep them outside the VM.
Have not touched any individual addons, but now at least git as addon works.

Bump version to 44.
Fixes broken path in parallels-tools installation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
